### PR TITLE
(doc) Fix markdown formatting

### DIFF
--- a/Chocolatey/self-hosted-integration-runtime/self-hosted-integration-runtime.nuspec
+++ b/Chocolatey/self-hosted-integration-runtime/self-hosted-integration-runtime.nuspec
@@ -19,17 +19,15 @@
     <summary>The latest version of Integration Runtime</summary>
     <description>The latest version of Integration Runtime at build time.
 
-      #### Supported Operating System
+#### Supported Operating System
 
-      Windows 10, Windows 11, Windows Server 2016, Windows Server 2019, Windows Server 2022
-      Download and run the IntergrationRuntime.msi (64-bit) to install the Integration Runtime on your computer
+Windows 10, Windows 11, Windows Server 2016, Windows Server 2019, Windows Server 2022
+Download and run the IntergrationRuntime.msi (64-bit) to install the Integration Runtime on your computer
 
-      Installation of the self-hosted integration runtime on a domain controller isn't supported.
+Installation of the self-hosted integration runtime on a domain controller isn't supported.
 
-      Self-hosted integration runtime requires a 64-bit Operating System with .NET Framework 4.7.2 or above. See .NET Framework System Requirements for details.
-      The recommended minimum configuration for the self-hosted integration runtime machine is a 2-GHz processor with 4 cores, 8 GB of RAM, and 80 GB of available hard drive space
-
-      
+Self-hosted integration runtime requires a 64-bit Operating System with .NET Framework 4.7.2 or above. See .NET Framework System Requirements for details.
+The recommended minimum configuration for the self-hosted integration runtime machine is a 2-GHz processor with 4 cores, 8 GB of RAM, and 80 GB of available hard drive space
     </description>
     <releaseNotes>https://www.microsoft.com/en-us/download/details.aspx?id=39717</releaseNotes>
     <dependencies>


### PR DESCRIPTION
This will make the markdown render correctly on the Chocolatey Community Repository:

<img width="1223" alt="image" src="https://github.com/user-attachments/assets/9e086b9a-5beb-476c-86f4-17a5185954a0">
